### PR TITLE
Fix icon import and usage in dashboard page

### DIFF
--- a/oddjobs/src/app/dashboard/page.js
+++ b/oddjobs/src/app/dashboard/page.js
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from 'next/link'
 import { useEffect, useState } from "react"
 import { supabase } from "@/lib/client"
 import StatCard from "@/components/dashboard/StatCard"
@@ -13,7 +14,7 @@ import {
   Plus, 
   Search, 
   RefreshCw, 
-  ChevronRight 
+  ChevronRight, 
 } from "lucide-react"
 
 // Remove the duplicate ArrowRight from Heroicons imports
@@ -336,7 +337,7 @@ setStats({
                   </div>
                 )}
               </div>
-              <ChevronRightIcon className="h-5 w-5 text-gray-400" />
+              <ChevronRight className="h-5 w-5 text-gray-400" />
             </div>
           </Link>
         )

--- a/oddjobs/src/components/layout/Header.js
+++ b/oddjobs/src/components/layout/Header.js
@@ -9,6 +9,7 @@ import ThemeToggle from '@/components/theme/ThemeToggle'
 // import toast from 'react-hot-toast'
 import { toast } from 'sonner'
 
+
 export default function Header() {
   const pathname = usePathname()
   const router = useRouter()


### PR DESCRIPTION
Replaces ChevronRightIcon from Heroicons with ChevronRight from lucide-react in dashboard/page.js for consistency. Also adds minor formatting adjustment in Header.js.