### PR TITLE
Add email sending API and settings enhancements

### DIFF
--- a/oddjobs/package-lock.json
+++ b/oddjobs/package-lock.json
@@ -42,6 +42,7 @@
         "react-hook-form": "^7.58.1",
         "react-icons": "^5.5.0",
         "recharts": "^3.1.0",
+        "resend": "^4.8.0",
         "sonner": "^2.0.5",
         "tailwind-merge": "^3.3.0",
         "tailwind-variants": "^1.0.0",
@@ -2463,6 +2464,24 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
+    "node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@react-spring/animated": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.1.tgz",
@@ -2577,6 +2596,19 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -4799,6 +4831,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4875,6 +4916,61 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -6054,6 +6150,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6673,6 +6804,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/levn": {
@@ -7496,6 +7636,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7536,6 +7689,15 @@
       "dev": true,
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -7608,6 +7770,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {
@@ -7936,6 +8113,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -8125,6 +8317,18 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resend": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.8.0.tgz",
+      "integrity": "sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -8305,6 +8509,18 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/oddjobs/package.json
+++ b/oddjobs/package.json
@@ -43,6 +43,7 @@
     "react-hook-form": "^7.58.1",
     "react-icons": "^5.5.0",
     "recharts": "^3.1.0",
+    "resend": "^4.8.0",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0",
     "tailwind-variants": "^1.0.0",

--- a/oddjobs/src/app/api/send/route.js
+++ b/oddjobs/src/app/api/send/route.js
@@ -1,0 +1,23 @@
+import { EmailTemplate } from '../../../components/email-template';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST() {
+  try {
+    const { data, error } = await resend.emails.send({
+      from: 'Acme <onboarding@resend.dev>',
+      to: ['delivered@resend.dev'],
+      subject: 'Hello world',
+      react: EmailTemplate({ firstName: 'John' }),
+    });
+
+    if (error) {
+      return Response.json({ error }, { status: 500 });
+    }
+
+    return Response.json(data);
+  } catch (error) {
+    return Response.json({ error }, { status: 500 });
+  }
+}

--- a/oddjobs/src/app/dashboard/settings/page.js
+++ b/oddjobs/src/app/dashboard/settings/page.js
@@ -8,17 +8,25 @@ import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "sonner"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 
 export default function DashboardSettingsPage() {
   const [user, setUser] = useState(null)
   const [profile, setProfile] = useState(null)
   const [loading, setLoading] = useState(true)
   const [updating, setUpdating] = useState(false)
+  const [formDisabled, setFormDisabled] = useState(true) // New state for disabling form
+  const [showModal, setShowModal] = useState(true) // New state for modal visibility
   const [formData, setFormData] = useState({
     name: "",
     email: "",
     visible: true,
     notificationsEnabled: false,
+  })
+  const [emailPreferences, setEmailPreferences] = useState({
+    jobUpdates: false,
+    newsletters: false,
+    promotions: false,
   })
 
   useEffect(() => {
@@ -48,6 +56,10 @@ export default function DashboardSettingsPage() {
           visible: profile.visible ?? true,
           notificationsEnabled: profile.notifications_enabled ?? false,
         })
+
+        if (profile.email_preferences) {
+          setEmailPreferences(profile.email_preferences)
+        }
       } catch (err) {
         toast.error("Failed to load settings", { description: err.message })
       } finally {
@@ -59,15 +71,48 @@ export default function DashboardSettingsPage() {
   }, [])
 
   const handleChange = (e) => {
+    if (formDisabled) return
     const { id, value } = e.target
     setFormData((prev) => ({ ...prev, [id]: value }))
   }
 
   const handleToggle = (id) => {
+    if (formDisabled) return
     setFormData((prev) => ({ ...prev, [id]: !prev[id] }))
   }
 
+  const handleEmailPreferenceChange = (preference) => {
+    if (formDisabled) return
+    setEmailPreferences((prev) => ({
+      ...prev,
+      [preference]: !prev[preference],
+    }))
+  }
+
+  const sendTestEmail = async () => {
+    if (formDisabled) return
+    try {
+      const response = await fetch('/api/send-email', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          to: formData.email,
+          subject: 'Test Email from Your App',
+          html: '<strong>This is a test email to confirm your notification settings are working!</strong>',
+        }),
+      })
+
+      if (!response.ok) throw new Error('Failed to send test email')
+      toast.success('Test email sent successfully!')
+    } catch (err) {
+      toast.error('Failed to send test email', { description: err.message })
+    }
+  }
+
   const handleSave = async () => {
+    if (formDisabled) return
     if (!formData.name.trim()) {
       return toast.error("Name is required")
     }
@@ -75,22 +120,48 @@ export default function DashboardSettingsPage() {
     try {
       setUpdating(true)
 
+      const updates = {
+        name: formData.name,
+        visible: formData.visible,
+        notifications_enabled: formData.notificationsEnabled,
+        email_preferences: emailPreferences,
+        updated_at: new Date().toISOString(),
+      }
+
       const { error } = await supabase
         .from("profiles")
-        .update({
-          name: formData.name,
-          visible: formData.visible,
-          notifications_enabled: formData.notificationsEnabled,
-        })
+        .update(updates)
         .eq("id", user.id)
 
       if (error) throw error
+
+      if (formData.notificationsEnabled && !profile?.notifications_enabled) {
+        await fetch('/api/send-email', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            to: formData.email,
+            subject: 'Notifications Enabled',
+            html: `<p>Hello ${formData.name},</p>
+                  <p>You've successfully enabled email notifications for your account.</p>
+                  <p>You'll receive updates about important events and activities.</p>`,
+          }),
+        })
+      }
+
       toast.success("Settings updated successfully!")
     } catch (err) {
       toast.error("Failed to update settings", { description: err.message })
     } finally {
       setUpdating(false)
     }
+  }
+
+  const handleModalClose = () => {
+    setShowModal(false)
+    setFormDisabled(true) // Keep form disabled after closing modal
   }
 
   if (loading) {
@@ -104,7 +175,42 @@ export default function DashboardSettingsPage() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto py-10 px-4 space-y-8">
+    <div className={`max-w-2xl mx-auto py-10 px-4 space-y-8 ${showModal ? 'blur-sm' : ''}`}>
+      {/* Under Construction Modal */}
+      <Dialog open={showModal} onOpenChange={handleModalClose}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-center">Feature Under Construction</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <p className="text-center text-muted-foreground">
+              This settings section is still in development. All fields will be disabled.
+            </p>
+            <div className="flex justify-center">
+              <Button onClick={handleModalClose}>I Understand</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Disabled Notice */}
+      {!showModal && (
+        <div className="p-4 bg-yellow-50 border-l-4 border-yellow-400 rounded">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+            </div>
+            <div className="ml-3">
+              <p className="text-sm text-yellow-700">
+                All fields are currently disabled as this section is under development.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="space-y-1">
         <h1 className="text-3xl font-bold">Settings</h1>
         <p className="text-muted-foreground">Manage your account and preferences</p>
@@ -120,6 +226,7 @@ export default function DashboardSettingsPage() {
             onChange={handleChange}
             placeholder="Enter your full name"
             required
+            disabled={formDisabled}
           />
         </div>
 
@@ -148,6 +255,7 @@ export default function DashboardSettingsPage() {
           <Switch
             checked={formData.visible}
             onCheckedChange={() => handleToggle("visible")}
+            disabled={formDisabled}
           />
         </div>
 
@@ -162,11 +270,79 @@ export default function DashboardSettingsPage() {
           <Switch
             checked={formData.notificationsEnabled}
             onCheckedChange={() => handleToggle("notificationsEnabled")}
+            disabled={formDisabled}
           />
         </div>
 
+        {/* Email Preferences */}
+        {formData.notificationsEnabled && (
+          <div className="space-y-4 border-t pt-6">
+            <Label>Email Preferences</Label>
+            <p className="text-sm text-muted-foreground">
+              Customize the types of emails you receive.
+            </p>
+            
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>Job Updates</Label>
+                  <p className="text-sm text-muted-foreground">
+                    New job postings and application updates.
+                  </p>
+                </div>
+                <Switch
+                  checked={emailPreferences.jobUpdates}
+                  onCheckedChange={() => handleEmailPreferenceChange("jobUpdates")}
+                  disabled={formDisabled}
+                />
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>Newsletters</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Weekly tips and industry news.
+                  </p>
+                </div>
+                <Switch
+                  checked={emailPreferences.newsletters}
+                  onCheckedChange={() => handleEmailPreferenceChange("newsletters")}
+                  disabled={formDisabled}
+                />
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>Promotions</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Special offers and discounts.
+                  </p>
+                </div>
+                <Switch
+                  checked={emailPreferences.promotions}
+                  onCheckedChange={() => handleEmailPreferenceChange("promotions")}
+                  disabled={formDisabled}
+                />
+              </div>
+            </div>
+            
+            <Button 
+              variant="outline" 
+              onClick={sendTestEmail}
+              className="mt-4"
+              disabled={formDisabled}
+            >
+              Send Test Email
+            </Button>
+          </div>
+        )}
+
         {/* Save Button */}
-        <Button className="w-full mt-6" onClick={handleSave} disabled={updating}>
+        <Button 
+          className="w-full mt-6" 
+          onClick={handleSave} 
+          disabled={updating || formDisabled}
+        >
           {updating ? "Saving..." : "Save Changes"}
         </Button>
       </div>

--- a/oddjobs/src/components/email-template.js
+++ b/oddjobs/src/components/email-template.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export function EmailTemplate({ firstName }) {
+  return (
+    <div>
+      <h1>Welcome, {firstName}!</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduces a new API route for sending emails using the Resend service and adds an email template component. The dashboard settings page now includes email notification preferences, a test email feature, and a modal indicating the section is under construction with all fields disabled. Updates dependencies to include 'resend'.